### PR TITLE
support passing JSON directly

### DIFF
--- a/src/frame.js
+++ b/src/frame.js
@@ -52,8 +52,8 @@ function convertJPGToHistogram(imgBuff) {
 	return getPixels(imgBuff).then(convertPixelsToHistogram);
 }
 
-function extractFramesFromTimeline(timelinePath) {
-	const trace = fs.readFileSync(timelinePath, 'utf-8');
+function extractFramesFromTimeline(timeline) {
+	const trace = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;
 
 	const model = new DevtoolsTimelineModel(trace);
 	const rawFrames = model.filmStripModel().frames();

--- a/src/index.js
+++ b/src/index.js
@@ -33,11 +33,11 @@ function calculateValues(frames) {
 
 /**
  * Retrieve speed index informations
- * @param  {string} timelinePath - path of the timeline to process
+ * @param  {string|Array} timeline path to the timeline to process, or the frames JSON
  * @return {Promise} resoving with an object containing the speed index informations
  */
-module.exports = function (timelinePath) {
-	return frame.extractFramesFromTimeline(timelinePath)
+module.exports = function (timeline) {
+	return frame.extractFramesFromTimeline(timeline)
 		.then(speedIndex.calculateVisualProgress)
 		.then(calculateValues);
 };

--- a/test/frame.js
+++ b/test/frame.js
@@ -39,3 +39,9 @@ test('extract frames from timeline should returns an array of frames', async t =
 	const frames = await frame.extractFramesFromTimeline('./assets/nyt.json');
 	t.true(Array.isArray(frames), 'Frames is not an array');
 });
+
+test('extract frames should support json', async t => {
+	const trace = JSON.parse(fs.readFileSync('./assets/progressive-app.json', 'utf-8'));
+	const frames = await frame.extractFramesFromTimeline(trace);
+	t.true(Array.isArray(frames), 'Frames is not an array');
+});


### PR DESCRIPTION
Requires #14, as it uses the `progressive-app.json` file.

For some reason, parsing the `nyt.json` JSON ourselves (i.e., using the old data in the test instead of the new file) outside the weird `vm.Script` context causes an error even though the devtools script just parses it too. I can't really work out why - something invalid in the nyt data?