### PR TITLE
2.5x performance boost

### DIFF
--- a/src/frame.js
+++ b/src/frame.js
@@ -4,10 +4,6 @@ import fs from 'fs';
 import jpeg from 'jpeg-js';
 import DevtoolsTimelineModel from 'devtools-timeline-model';
 
-const getPixels = (buff) => {
-	return Promise.resolve(jpeg.decode(buff));
-};
-
 function getPixel(x, y, channel, width, buff) {
 	return buff[(x + y * width) * 4 + channel];
 }
@@ -48,10 +44,6 @@ function convertPixelsToHistogram(img) {
 	return histograms;
 }
 
-function convertJPGToHistogram(imgBuff) {
-	return getPixels(imgBuff).then(convertPixelsToHistogram);
-}
-
 function extractFramesFromTimeline(timelinePath) {
 	const trace = fs.readFileSync(timelinePath, 'utf-8');
 
@@ -82,16 +74,13 @@ function frame(imgBuff, ts) {
 
 	return {
 		getHistogram: function () {
-			return Promise.resolve().then(() => {
-				if (_histogram) {
-					return _histogram;
-				}
+			if (_histogram) {
+				return _histogram;
+			}
 
-				return convertJPGToHistogram(imgBuff).then(function (histogram) {
-					_histogram = histogram;
-					return _histogram;
-				});
-			});
+			const pixels = jpeg.decode(imgBuff);
+			_histogram = convertPixelsToHistogram(pixels);
+			return _histogram;
 		},
 
 		getTimeStamp: function () {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 'use strict';
 
 import frame from './frame';
-import speedIndex from './speed-index';
+import {
+	calculateVisualProgress,
+	calculateSpeedIndex
+} from './speed-index';
 
 function calculateValues(frames) {
 	const startTs = frames[0].getTimeStamp();
@@ -27,7 +30,7 @@ function calculateValues(frames) {
 		first,
 		complete,
 		duration,
-		speedIndex: Math.floor(speedIndex.calculateSpeedIndex(frames))
+		speedIndex: Math.floor(calculateSpeedIndex(frames))
 	};
 }
 
@@ -37,7 +40,12 @@ function calculateValues(frames) {
  * @return {Promise} resoving with an object containing the speed index informations
  */
 module.exports = function (timelinePath) {
-	return frame.extractFramesFromTimeline(timelinePath)
-		.then(speedIndex.calculateVisualProgress)
-		.then(calculateValues);
+	console.time('extract');
+	return frame.extractFramesFromTimeline(timelinePath).then(function (frames) {
+		console.timeEnd('extract');
+		console.time('progress');
+		calculateVisualProgress(frames);
+		console.timeEnd('progress');
+		return calculateValues(frames);
+	});
 };

--- a/src/index.js
+++ b/src/index.js
@@ -40,12 +40,8 @@ function calculateValues(frames) {
  * @return {Promise} resoving with an object containing the speed index informations
  */
 module.exports = function (timelinePath) {
-	console.time('extract');
 	return frame.extractFramesFromTimeline(timelinePath).then(function (frames) {
-		console.timeEnd('extract');
-		console.time('progress');
 		calculateVisualProgress(frames);
-		console.timeEnd('progress');
 		return calculateValues(frames);
 	});
 };

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -7,20 +7,21 @@ import speedIndex from '../lib/speed-index';
 function calculateVisualProgressFromImages(images = [], delay = 1000) {
 	const baseTs = new Date().getTime();
 
-	return Promise.all(images.map((imgPath, i) => {
+	const frames = images.map((imgPath, i) => {
 		const imgBuff = fs.readFileSync(imgPath);
 		return frame.create(imgBuff, baseTs + i * delay);
-	}))
-	.then(ret => speedIndex.calculateVisualProgress(ret).then(() => ret));
+	});
+
+	return speedIndex.calculateVisualProgress(frames);
 }
 
 test('visual progress should be 100 if there is a single frame only', async t => {
-	const frames = await calculateVisualProgressFromImages(['./assets/grayscale.jpg']);
+	const frames = calculateVisualProgressFromImages(['./assets/grayscale.jpg']);
 	t.is(frames[0].getProgress(), 100);
 });
 
 test('visual progress should be 100 if there is not change', async t => {
-	const frames = await calculateVisualProgressFromImages([
+	const frames = calculateVisualProgressFromImages([
 		'./assets/grayscale.jpg',
 		'./assets/grayscale.jpg'
 	]);
@@ -31,7 +32,7 @@ test('visual progress should be 100 if there is not change', async t => {
 });
 
 test('visual progress should have 0 and 100 for different images', async t => {
-	const frames = await calculateVisualProgressFromImages([
+	const frames = calculateVisualProgressFromImages([
 		'./assets/Solid_black.jpg',
 		'./assets/grayscale.jpg'
 	]);
@@ -41,10 +42,10 @@ test('visual progress should have 0 and 100 for different images', async t => {
 });
 
 test('speed index calculate teh right value', async t => {
-	const res = await calculateVisualProgressFromImages([
+	const frames = calculateVisualProgressFromImages([
 		'./assets/Solid_black.jpg',
 		'./assets/grayscale.jpg'
-	]).then(speedIndex.calculateSpeedIndex);
+	]);
 
-	t.is(res, 1000);
+	t.is(speedIndex.calculateSpeedIndex(frames), 1000);
 });


### PR DESCRIPTION
The [_histogram cache](https://github.com/pmdartus/speedline/blob/405b0d0ae72cee72545c3f6c193871008cdbfc10/src/frame.js#L86) in the frames objects was never hit, because of the way promises are scheduled.

Solved by making the `getHistogram()` method synchronous. 

--

Before:
<img width="610" alt="screen shot 2016-04-24 at 15 08 40" src="https://cloud.githubusercontent.com/assets/2567083/14767789/97d8baf0-0a2e-11e6-93b9-cf77ee550d7a.png">
After:
<img width="629" alt="screen shot 2016-04-24 at 15 08 28" src="https://cloud.githubusercontent.com/assets/2567083/14767791/a0647894-0a2e-11e6-90cc-cf6639a968f6.png">