### PR TITLE
bump to latest devtools-timeline-model

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "babar": "0.0.3",
-    "devtools-timeline-model": "^1.0.18",
+    "devtools-timeline-model": "^1.1.2",
     "jpeg-js": "^0.1.2",
     "loud-rejection": "^1.3.0",
     "meow": "^3.7.0"


### PR DESCRIPTION
Made some minor updates to bring into alignment with lighthouse.
Now that lighthouse is bringing in speedline, I'd love to get these deps matching up.

of note in the latest version, dtm tests validate [all is good with speedline](https://github.com/paulirish/devtools-timeline-model/blob/master/test/speedline.js)