### PR TITLE
Allow extractFramesFromTimeline to absorb an existing model

### DIFF
--- a/src/frame.js
+++ b/src/frame.js
@@ -45,9 +45,13 @@ function convertPixelsToHistogram(img) {
 }
 
 function extractFramesFromTimeline(timeline) {
-	const trace = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;
-
-	const model = new DevtoolsTimelineModel(trace);
+	let model;
+	if (timeline.frameModel) {
+		model = timeline;
+	} else {
+		const trace = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;
+		model = new DevtoolsTimelineModel(trace);
+	}
 	const rawFrames = model.filmStripModel().frames();
 
 	const timelineModel = model.timelineModel();

--- a/src/frame.js
+++ b/src/frame.js
@@ -46,7 +46,7 @@ function convertPixelsToHistogram(img) {
 
 function extractFramesFromTimeline(timeline) {
 	let model;
-	if (timeline.frameModel) {
+	if (timeline instanceof DevtoolsTimelineModel) {
 		model = timeline;
 	} else {
 		const trace = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;

--- a/test/frame.js
+++ b/test/frame.js
@@ -38,18 +38,18 @@ test('frames can set and retrieve progress', t => {
 
 test('extract frames from timeline should returns an array of frames', async t => {
 	const frames = await frame.extractFramesFromTimeline('./assets/nyt.json');
-	t.true(Array.isArray(frames), 'Frames is an array');
+	t.true(Array.isArray(frames), 'Frames is not an array');
 });
 
 test('extract frames should support json', async t => {
 	const trace = JSON.parse(fs.readFileSync('./assets/progressive-app.json', 'utf-8'));
 	const frames = await frame.extractFramesFromTimeline(trace);
-	t.true(Array.isArray(frames), 'Frames is an array');
+	t.true(Array.isArray(frames), 'Frames is not an array');
 });
 
 test('extract frames should support a devtools-timeline-model', async t => {
 	const trace = JSON.parse(fs.readFileSync('./assets/progressive-app.json', 'utf-8'));
 	const model = new DevtoolsTimelineModel(trace);
 	const frames = await frame.extractFramesFromTimeline(model);
-	t.true(Array.isArray(frames), 'Frames is an array');
+	t.true(Array.isArray(frames), 'Frames is not an array');
 });

--- a/test/frame.js
+++ b/test/frame.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import test from 'ava';
+import DevtoolsTimelineModel from 'devtools-timeline-model';
 import frame from '../lib/frame';
 
 const DEFAULT_IMAGE = fs.readFileSync('./assets/Solid_black.jpg');
@@ -37,11 +38,18 @@ test('frames can set and retrieve progress', t => {
 
 test('extract frames from timeline should returns an array of frames', async t => {
 	const frames = await frame.extractFramesFromTimeline('./assets/nyt.json');
-	t.true(Array.isArray(frames), 'Frames is not an array');
+	t.true(Array.isArray(frames), 'Frames is an array');
 });
 
 test('extract frames should support json', async t => {
 	const trace = JSON.parse(fs.readFileSync('./assets/progressive-app.json', 'utf-8'));
 	const frames = await frame.extractFramesFromTimeline(trace);
-	t.true(Array.isArray(frames), 'Frames is not an array');
+	t.true(Array.isArray(frames), 'Frames is an array');
+});
+
+test('extract frames should support a devtools-timeline-model', async t => {
+	const trace = JSON.parse(fs.readFileSync('./assets/progressive-app.json', 'utf-8'));
+	const model = new DevtoolsTimelineModel(trace);
+	const frames = await frame.extractFramesFromTimeline(model);
+	t.true(Array.isArray(frames), 'Frames is an array');
 });


### PR DESCRIPTION
In lighthouse, our most expensive main thread work is recomputing the trace model. (we currently do it 3 times.)

If we can pass a parsed model directly into speedline, we'd speed up things a bit.
