### PR TITLE
Build frames off the raw trace.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   ],
   "dependencies": {
     "babar": "0.0.3",
-    "devtools-timeline-model": "^1.1.5",
     "image-ssim": "^0.2.0",
     "jpeg-js": "^0.1.2",
     "loud-rejection": "^1.3.0",

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ speedline('./timeline').then(results => {
 
 #### `speedline(timeline)`
 
-* (string | object[] | DevtoolsTimelineModel) `timeline`
+* (string | object[]) `timeline`
 * returns (Promise) resolving with an object containing:
   * `speedIndex` (number) - speed index value.
   * `perceptualSpeedIndex` (number) - perceptual speed index value.
@@ -71,8 +71,7 @@ speedline('./timeline').then(results => {
 
 If the type of the timeline parameter is:
 * `string` - the parameter represents the location of the of file containing the timeline.
-* `array` - the parameter represents the content of the timeline file.
-* `DevtoolsTimelineModel` - the parameter represents the parsed content of the timeline. It avoids recomputing the timeline model if you call this method several times.
+* `array` - the parameter represents the traceEvents content of the timeline file.
 
 #### `Frame`
 

--- a/src/frame.js
+++ b/src/frame.js
@@ -43,7 +43,7 @@ function convertPixelsToHistogram(img) {
 	return histograms;
 }
 
-const screenshot_trace_category = 'disabled-by-default-devtools.screenshot';
+const screenshotTraceCategory = 'disabled-by-default-devtools.screenshot';
 function extractFramesFromTimeline(timeline) {
 	let trace;
 	trace = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;
@@ -58,7 +58,7 @@ function extractFramesFromTimeline(timeline) {
 	const start = events[0].ts / 1000;
 	const end = events[events.length - 1].ts / 1000;
 
-	const rawScreenshots = events.filter(e => e.cat.includes(screenshot_trace_category));
+	const rawScreenshots = events.filter(e => e.cat.includes(screenshotTraceCategory));
 	const frames = rawScreenshots.map(function (evt) {
 		const base64img = evt.args && evt.args.snapshot;
 		const timestamp = evt.ts / 1000;

--- a/src/frame.js
+++ b/src/frame.js
@@ -2,7 +2,6 @@
 
 import fs from 'fs';
 import jpeg from 'jpeg-js';
-import DevtoolsTimelineModel from 'devtools-timeline-model';
 
 function getPixel(x, y, channel, width, buff) {
 	return buff[(x + y * width) * 4 + channel];
@@ -44,32 +43,33 @@ function convertPixelsToHistogram(img) {
 	return histograms;
 }
 
+const screenshot_trace_category = 'disabled-by-default-devtools.screenshot';
 function extractFramesFromTimeline(timeline) {
-	let model;
-	if (timeline instanceof DevtoolsTimelineModel) {
-		model = timeline;
-	} else {
-		const trace = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;
-		model = new DevtoolsTimelineModel(trace);
+	let trace;
+	trace = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;
+	try {
+		trace = typeof trace === 'string' ? JSON.parse(trace) : trace;
+	} catch (e) {
+		throw new Error('Speedline: Invalid JSON' + e.message);
 	}
-	const rawFrames = model.filmStripModel().frames();
+	let events = trace.traceEvents || trace;
+	events = events.sort((a, b) => a.ts - b.ts).filter(e => e.ts !== 0);
 
-	const timelineModel = model.timelineModel();
-	const start = timelineModel.minimumRecordTime();
-	const end = timelineModel.maximumRecordTime();
+	const start = events[0].ts / 1000;
+	const end = events[events.length - 1].ts / 1000;
 
-	return Promise.all(rawFrames.map(f => f.imageDataPromise())).then(ret => {
-		return Promise.all(ret.map(function (img, index) {
-			const imgBuff = new Buffer(img, 'base64');
-			return frame(imgBuff, rawFrames[index].timestamp);
-		}))
-		.then(function (frames) {
-			const firstFrame = frame(frames[0].getImage(), start);
-			const lastFrame = frame(frames[frames.length - 1].getImage(), end);
+	const rawScreenshots = events.filter(e => e.cat.includes(screenshot_trace_category));
+	const frames = rawScreenshots.map(function (evt) {
+		const base64img = evt.args && evt.args.snapshot;
+		const timestamp = evt.ts / 1000;
 
-			return [firstFrame, ...frames, lastFrame];
-		});
+		const imgBuff = new Buffer(base64img, 'base64');
+		return frame(imgBuff, timestamp);
 	});
+
+	const firstFrame = frame(frames[0].getImage(), start);
+	const lastFrame = frame(frames[frames.length - 1].getImage(), end);
+	return Promise.resolve([firstFrame, ...frames, lastFrame]);
 }
 
 function frame(imgBuff, ts) {

--- a/test/frame.js
+++ b/test/frame.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import test from 'ava';
-import DevtoolsTimelineModel from 'devtools-timeline-model';
 import frame from '../lib/frame';
 
 const DEFAULT_IMAGE = fs.readFileSync('./assets/Solid_black.jpg');
@@ -44,12 +43,5 @@ test('extract frames from timeline should returns an array of frames', async t =
 test('extract frames should support json', async t => {
 	const trace = JSON.parse(fs.readFileSync('./assets/progressive-app.json', 'utf-8'));
 	const frames = await frame.extractFramesFromTimeline(trace);
-	t.true(Array.isArray(frames), 'Frames is not an array');
-});
-
-test('extract frames should support a devtools-timeline-model', async t => {
-	const trace = JSON.parse(fs.readFileSync('./assets/progressive-app.json', 'utf-8'));
-	const model = new DevtoolsTimelineModel(trace);
-	const frames = await frame.extractFramesFromTimeline(model);
 	t.true(Array.isArray(frames), 'Frames is not an array');
 });


### PR DESCRIPTION
In a weird twist, I'm interested in removing the dependency on my own module.
And speedline was my first ever customer! 😿 

There is some fragility between the framesModel and screenshots in a trace. Basically DevTools builds the frames model based on compositor thread activity, and then correlates screenshots (taken on the browser process) by seeing [if the two timestamps are close by](https://cs.chromium.org/chromium/src/third_party/WebKit/Source/devtools/front_end/timeline/TimelinePanel.js?dr=C&q=f:front_end+f:timelinepanel+filmStripFrame&sq=package:chromium&l=1044). In practice, I haven't yet seen this be a problem, though it's in the back of my mind.

Since speed index is all about what was painted, it's more effective to just grab all the screenshots right out of the trace. So that's what this PR does.

Ran this on a few traces so far and the numbers are identical.

It's faster now, as well. For a 13MB trace, it took 5.3s before and now 3.5s.

What do ya'll think? No rush.